### PR TITLE
Add a 'home' url for reverse resolution

### DIFF
--- a/openquakeplatform_taxtweb/urls.py
+++ b/openquakeplatform_taxtweb/urls.py
@@ -30,4 +30,5 @@ urlpatterns = patterns(
     '',
     url(r'^/checker(?P<taxonomy>[^?]*)', views.checker, name='checker'),
     url(r'^(?P<taxonomy>[^?]*)', views.index, name='index'),
+    url('', views.index, name='home'),
 )


### PR DESCRIPTION
Add an 'empty' home url. This is used by the reverse resolution, since 'index' does not work there because parameters are needed.
