### PR TITLE
Remove unused imports and make flake8 more happy

### DIFF
--- a/openquakeplatform_taxtweb/__init__.py
+++ b/openquakeplatform_taxtweb/__init__.py
@@ -1,3 +1,2 @@
-header_info = { "title": "TaxtWEB" }
+header_info = {"title": "TaxtWEB"}
 __version__ = '1.2.0'
-

--- a/openquakeplatform_taxtweb/__init__.py
+++ b/openquakeplatform_taxtweb/__init__.py
@@ -1,2 +1,20 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2015-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
 header_info = {"title": "TaxtWEB"}
 __version__ = '1.2.0'

--- a/openquakeplatform_taxtweb/mat_and_llrs.py
+++ b/openquakeplatform_taxtweb/mat_and_llrs.py
@@ -1,3 +1,21 @@
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
+#
+# Copyright (C) 2015-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
+
 taxt_mat = (
     ('MAT99', 'Unknown Material'),
     ('C99', 'Concrete, unknown reinforcement'),

--- a/openquakeplatform_taxtweb/urls.py
+++ b/openquakeplatform_taxtweb/urls.py
@@ -1,21 +1,20 @@
 # -*- coding: utf-8 -*-
 # vim: tabstop=4 shiftwidth=4 softtabstop=4
-
-# Copyright (c) 2015, GEM Foundation.
 #
-#    This program is free software: you can redistribute it and/or modify
-#    it under the terms of the GNU Affero General Public License as
-#    published by the Free Software Foundation, either version 3 of the
-#    License, or (at your option) any later version.
+# Copyright (C) 2015-2017 GEM Foundation
 #
-#    This program is distributed in the hope that it will be useful,
-#    but WITHOUT ANY WARRANTY; without even the implied warranty of
-#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-#    GNU Affero General Public License for more details.
+# OpenQuake is free software: you can redistribute it and/or modify it
+# under the terms of the GNU Affero General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
 #
-#    You should have received a copy of the GNU Affero General Public
-#    License along with this program. If not, see
-#    <https://www.gnu.org/licenses/agpl.html>.
+# OpenQuake is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from django.conf.urls import url
 from openquakeplatform_taxtweb import views

--- a/openquakeplatform_taxtweb/views.py
+++ b/openquakeplatform_taxtweb/views.py
@@ -109,12 +109,12 @@ def checker(request, **kwargs):
     sub1tab_content = ""
 
     return render(request, "taxtweb/checker.html",
-                           dict(taxonomy=taxonomy,
-                                is_popup=is_popup,
-                                tab_id=tab_id,
-                                subtab_id=subtab_id,
-                                tab_content=tab_content,
-                                sub1tab_content=sub1tab_content,
-                                taxt_prefix=taxt_prefix,
-                                jquery="sim_dollar",
-                                ))
+                  dict(taxonomy=taxonomy,
+                       is_popup=is_popup,
+                       tab_id=tab_id,
+                       subtab_id=subtab_id,
+                       tab_content=tab_content,
+                       sub1tab_content=sub1tab_content,
+                       taxt_prefix=taxt_prefix,
+                       jquery="sim_dollar",
+                       ))

--- a/openquakeplatform_taxtweb/views.py
+++ b/openquakeplatform_taxtweb/views.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2015, GEM Foundation.
+# Copyright (c) 2015-2017, GEM Foundation.
 #
 # This program is free software: you can redistribute it and/or modify
 # under the terms of the GNU Affero General Public License as published
@@ -13,28 +13,15 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
-from django.conf import settings
-
-import json
-from scipy import stats
-import numpy
-from lxml import etree
-from django.http import HttpResponse, HttpResponseNotFound, Http404
-from django.core import serializers
-from django.core.serializers.json import DjangoJSONEncoder
 from django.shortcuts import render
-from django.template import RequestContext
-from django.views.generic.detail import BaseDetailView
-from django.utils.cache import add_never_cache_headers
-from django.utils.text import slugify
-from django.contrib.messages.api import get_messages
+
 
 def index(request, **kwargs):
     try:
         tab_id = int(request.GET.get("tab_id", 1))
         if tab_id < 1 or tab_id > 4:
             tab_id = 1
-    except ValueError as e:
+    except ValueError:
         tab_id = 1
 
     subtab_id = 1
@@ -44,7 +31,7 @@ def index(request, **kwargs):
             if subtab_id < 1 or subtab_id > 2:
                 subtab_id = 1
                 print "MOP: qui %d" % subtab_id
-        except ValueError as e:
+        except ValueError:
             subtab_id = 1
 
     if 'HTTP_HOST' in request.META:
@@ -53,11 +40,15 @@ def index(request, **kwargs):
         if request.META['HTTP_HOST'].startswith('taxtweb'):
             taxt_prefix = proto + '://' + request.META['HTTP_HOST']
         else:
-            taxt_prefix = proto + '://' + request.META['HTTP_HOST'] + '/taxtweb'
+            taxt_prefix = (proto + '://' + request.META['HTTP_HOST']
+                           + '/taxtweb')
     else:
         taxt_prefix = "http://taxtweb.openquake.org"
 
-    desc = [ 'Structural System', 'Building Information', 'Exterior Attributes', 'Roof/Floor/Foundation' ]
+    desc = ['Structural System',
+            'Building Information',
+            'Exterior Attributes',
+            'Roof/Floor/Foundation']
     tab_content = ""
     for i in range(0, len(desc)):
         tab_content = (tab_content +
@@ -81,16 +72,17 @@ def index(request, **kwargs):
 
     taxonomy = kwargs['taxonomy'] if 'taxonomy' in kwargs else ""
 
-    return render(request, ("taxtweb/index_popup.html" if is_popup else "taxtweb/index.html"),
-                              dict(taxonomy=taxonomy,
-                                   is_popup=is_popup,
-                                   tab_id=tab_id,
-                                   subtab_id=subtab_id,
-                                   tab_content=tab_content,
-                                   sub1tab_content=sub1tab_content,
-                                   taxt_prefix=taxt_prefix,
-                                   jquery="$",
-                                   ))
+    return render(request, ("taxtweb/index_popup.html" if is_popup
+                            else "taxtweb/index.html"),
+                  dict(taxonomy=taxonomy,
+                       is_popup=is_popup,
+                       tab_id=tab_id,
+                       subtab_id=subtab_id,
+                       tab_content=tab_content,
+                       sub1tab_content=sub1tab_content,
+                       taxt_prefix=taxt_prefix,
+                       jquery="$",
+                       ))
 
 
 def checker(request, **kwargs):
@@ -102,10 +94,10 @@ def checker(request, **kwargs):
         if request.META['HTTP_HOST'].startswith('taxtweb'):
             taxt_prefix = proto + '://' + request.META['HTTP_HOST']
         else:
-            taxt_prefix = proto + '://' + request.META['HTTP_HOST'] + '/taxtweb'
+            taxt_prefix = (proto + '://' + request.META['HTTP_HOST']
+                           + '/taxtweb')
     else:
         taxt_prefix = "http://taxtweb.openquake.org"
-
 
     is_popup = ""
     tab_id = ""
@@ -114,12 +106,12 @@ def checker(request, **kwargs):
     sub1tab_content = ""
 
     return render(request, "taxtweb/checker.html",
-                              dict(taxonomy=taxonomy,
-                                   is_popup=is_popup,
-                                   tab_id=tab_id,
-                                   subtab_id=subtab_id,
-                                   tab_content=tab_content,
-                                   sub1tab_content=sub1tab_content,
-                                   taxt_prefix=taxt_prefix,
-                                   jquery="sim_dollar",
-                                   ))
+                           dict(taxonomy=taxonomy,
+                                is_popup=is_popup,
+                                tab_id=tab_id,
+                                subtab_id=subtab_id,
+                                tab_content=tab_content,
+                                sub1tab_content=sub1tab_content,
+                                taxt_prefix=taxt_prefix,
+                                jquery="sim_dollar",
+                                ))

--- a/openquakeplatform_taxtweb/views.py
+++ b/openquakeplatform_taxtweb/views.py
@@ -1,17 +1,20 @@
-# Copyright (c) 2015-2017, GEM Foundation.
+# -*- coding: utf-8 -*-
+# vim: tabstop=4 shiftwidth=4 softtabstop=4
 #
-# This program is free software: you can redistribute it and/or modify
+# Copyright (C) 2015-2017 GEM Foundation
+#
+# OpenQuake is free software: you can redistribute it and/or modify it
 # under the terms of the GNU Affero General Public License as published
 # by the Free Software Foundation, either version 3 of the License, or
 # (at your option) any later version.
 #
-# This program is distributed in the hope that it will be useful,
+# OpenQuake is distributed in the hope that it will be useful,
 # but WITHOUT ANY WARRANTY; without even the implied warranty of
 # MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-# GNU General Public License for more details.
+# GNU Affero General Public License for more details.
 #
 # You should have received a copy of the GNU Affero General Public License
-# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+# along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 from django.shortcuts import render
 


### PR DESCRIPTION
Main goasl was removing the `lxml` import which is currently blocking the integration with engine.

See also https://github.com/gem/oq-platform-ipt/pull/28

Tests: https://ci.openquake.org/job/zdevel_oq-platform-standalone/71/