### PR TITLE
More fixes for python3

### DIFF
--- a/openquakeplatform_taxtweb/bin/pythonify.sh
+++ b/openquakeplatform_taxtweb/bin/pythonify.sh
@@ -53,7 +53,7 @@ vars_to_py () {
             sed "s/\b\([a-z]\+\):/'\1':/g" | \
             sed 's/\(.* = *\)$/\1 \\/g'
         echo "if __name__ == '__main__':"
-        echo "    print __name__"
+        echo "    print(__name__)"
     ) > ${TMPD}/tmp.$$
 
     IFS='

--- a/openquakeplatform_taxtweb/test_old/reorder.py
+++ b/openquakeplatform_taxtweb/test_old/reorder.py
@@ -32,9 +32,9 @@ def main():
                csv_wri.writerow(i)
                old = i[3]
                if i[4] == "WARNING":
-                    print "------"
-                    print "%s" % i[3]
-                    print "%s" % i[6]
+                    print("------")
+                    print("%s" % i[3])
+                    print("%s" % i[6])
 
      fo.close()
 

--- a/openquakeplatform_taxtweb/test_old/taxtweb-test.py
+++ b/openquakeplatform_taxtweb/test_old/taxtweb-test.py
@@ -14,8 +14,8 @@ import csv
 from config import basepath
 
 if basepath == "":
-    print "configuration 'basepath' variable is empty."
-    print "Please edit config.py file following the included instructions."
+    print("configuration 'basepath' variable is empty.")
+    print("Please edit config.py file following the included instructions.")
     sys.exit(1)
 
 newarr = []
@@ -54,7 +54,7 @@ with open('taxonomies.csv', 'rb') as csvfile:
         
         line = line.replace("MUR/ST99", "MUR+ST99")
 
-        print "LINE: " + line
+        print("LINE: " + line)
         driver.get(basepath + line)
 
         alert = True
@@ -65,7 +65,7 @@ with open('taxonomies.csv', 'rb') as csvfile:
             try:
                 alert = driver.switch_to_alert()
                 alert_str = alert_str + alert.text.replace("\n", " ")
-                print "ERROR: [%s]" % alert.text
+                print("ERROR: [%s]" % alert.text)
                 alert.accept()
                 alert_count += 1
             except NoAlertPresentException:
@@ -107,5 +107,5 @@ with open('out.csv', 'wb') as csvfile:
 #finally:
 driver.quit()
 
-print "WIN"
+print("WIN")
 

--- a/openquakeplatform_taxtweb/utils/taxtweb_eng.py
+++ b/openquakeplatform_taxtweb/utils/taxtweb_eng.py
@@ -4003,7 +4003,7 @@ if __name__ == '__main__':
         line_norm = re.sub('\+*/\+*', '/', line_norm)
         line_norm = re.sub('[/\+]+$', '', line_norm)
         line_norm = re.sub('/+', '/', line_norm)
-        print "==== %s ==== (%s) =========" % (line, line_norm)
+        print( "==== %s ==== (%s) =========" % (line, line_norm))
 
         for i in range(0, 10):
             if line[-1] == '/':
@@ -4013,24 +4013,24 @@ if __name__ == '__main__':
 
         ret1 = taxonomy.process(line, 0)
         if ret1[1]:
-            print "ERROR1: [%s] [%s]\n" % (line, ret1[1])
+            print("ERROR1: [%s] [%s]\n" % (line, ret1[1]))
             continue
         ret2 = taxonomy.process(ret1[0], 1)
         if ret2[1]:
-            print "ERROR2: [%s] [%s]\n" % (line, ret2[1])
+            print("ERROR2: [%s] [%s]\n" % (line, ret2[1]))
             continue
         ret2_norm = re.sub('/+', '/', ret2[0])
         ret2_norm = re.sub('/+$', '', ret2_norm)
 
         ret3 = taxonomy.process(ret2[0], 2)
         if ret3[1]:
-            print "ERROR3: [%s] [%s]\n" % (line, ret3[1])
+            print("ERROR3: [%s] [%s]\n" % (line, ret3[1]))
             continue
 
         if line == ret1[0] or line == ret2[0] or line == ret3[0]:
-            print "SUCCESS:\n ->[%s]\n   [%s]\n   [%s]\n <-[%s]\n" % (line, ret1[0], ret2[0], ret3[0])
+            print("SUCCESS:\n ->[%s]\n   [%s]\n   [%s]\n <-[%s]\n" % (line, ret1[0], ret2[0], ret3[0]))
         elif line_norm == ret1[0] or line_norm == ret2[0] or line_norm == ret2_norm or line_norm == ret3[0]:
-            print "RENORM: \n ->[%s]\n   [%s]\n   [%s]\n n>[%s]\n n<[%s]\n <-[%s]\n" % (line_norm, ret1[0], ret2[0], line_norm, ret2_norm, ret3[0])
+            print("RENORM: \n ->[%s]\n   [%s]\n   [%s]\n n>[%s]\n n<[%s]\n <-[%s]\n" % (line_norm, ret1[0], ret2[0], line_norm, ret2_norm, ret3[0]))
         else:
             a = line_norm[:]
             b = ret2_norm[:]
@@ -4045,4 +4045,4 @@ if __name__ == '__main__':
                     r += " "
                 else:
                     r += a[c] if a[c] != " " else b[c]
-            print "DIFFER: \n ->[%s]\n   [%s]\n   [%s]\n <-[%s]\n n>[%s]\n n<[%s]\n n![%s]\n" % (line, ret1[0], ret2[0], ret3[0], line_norm, ret2_norm, r)
+            print("DIFFER: \n ->[%s]\n   [%s]\n   [%s]\n <-[%s]\n n>[%s]\n n<[%s]\n n![%s]\n" % (line, ret1[0], ret2[0], ret3[0], line_norm, ret2_norm, r))

--- a/openquakeplatform_taxtweb/utils/taxtweb_head.py
+++ b/openquakeplatform_taxtweb/utils/taxtweb_head.py
@@ -152,4 +152,4 @@ floo_conn =\
     }
 
 if __name__ == '__main__':
-    print __name__
+    print(__name__)

--- a/openquakeplatform_taxtweb/utils/taxtweb_maps.py
+++ b/openquakeplatform_taxtweb/utils/taxtweb_maps.py
@@ -499,4 +499,4 @@ foun_type = [
                  { 'id': 'FOSO', 'desc': 'Foundation, other' }
                ]
 if __name__ == '__main__':
-    print __name__
+    print(__name__)


### PR DESCRIPTION
To avoid errors during `compileall`:

```python
Compiling 'Lib/site-packages/openquakeplatform_taxtweb/test_old/reorder.py'...
***   File "Lib/site-packages/openquakeplatform_taxtweb/test_old/reorder.py", line 35
    print "------"
                 ^
SyntaxError: Missing parentheses in call to 'print'

Compiling 'Lib/site-packages/openquakeplatform_taxtweb/test_old/taxtweb-test.py'...
***   File "Lib/site-packages/openquakeplatform_taxtweb/test_old/taxtweb-test.py", line 17
    print "configuration 'basepath' variable is empty."
                                                      ^
SyntaxError: Missing parentheses in call to 'print'

Listing 'Lib/site-packages/openquakeplatform_taxtweb/utils'...
Compiling 'Lib/site-packages/openquakeplatform_taxtweb/utils/taxtweb_eng.py'...
***   File "Lib/site-packages/openquakeplatform_taxtweb/utils/taxtweb_eng.py", line 3956
    convert an input taxonomy to a normalized form if correct else an error is returned.
             ^
SyntaxError: invalid syntax

Compiling 'Lib/site-packages/openquakeplatform_taxtweb/utils/taxtweb_head.py'...
***   File "Lib/site-packages/openquakeplatform_taxtweb/utils/taxtweb_head.py", line 155
    print __name__
                 ^
SyntaxError: Missing parentheses in call to 'print'

Compiling 'Lib/site-packages/openquakeplatform_taxtweb/utils/taxtweb_maps.py'...
***   File "Lib/site-packages/openquakeplatform_taxtweb/utils/taxtweb_maps.py", line 502
    print __name__
                 ^
SyntaxError: Missing parentheses in call to 'print'
```