### PR TITLE
Make app compatible with Django 2.0+

### DIFF
--- a/openquakeplatform_taxtweb/urls.py
+++ b/openquakeplatform_taxtweb/urls.py
@@ -23,6 +23,7 @@ from openquakeplatform_taxtweb import views
 # from django.contrib import admin
 # admin.autodiscover()
 
+app_name = 'taxtweb'
 urlpatterns = [
     url(r'^checker(?P<taxonomy>[^?]*)', views.checker, name='checker'),
     url(r'^(?P<taxonomy>[^?]*)', views.index, name='index'),

--- a/setup.py
+++ b/setup.py
@@ -19,7 +19,7 @@ setup(
     author='GEM Foundation',
     author_email='devops@openquake.org',
     install_requires=[
-        'django >=1.5, <1.11',
+        'django >=1.5, <2.1',
     ],
     classifiers=[
         'Environment :: Web Environment',


### PR DESCRIPTION
Required by: https://github.com/gem/oq-engine/pull/3580

It's backward compatible.

https://ci.openquake.org/job/zdevel_oq-platform-standalone/234/