### PR TITLE
Fix levels

### DIFF
--- a/openquakeplatform_taxtweb/__init__.py
+++ b/openquakeplatform_taxtweb/__init__.py
@@ -17,4 +17,4 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 header_info = {"title": "TaxtWEB"}
-__version__ = '1.2.2'
+__version__ = '1.2.3'

--- a/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_content.html
+++ b/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_content.html
@@ -208,11 +208,11 @@
                </tr></table>
 
                 <table style="width: 95%;"><tr>
-                    <td style="width: 33%;"><div><span data-gem-help="{{ taxonomy_base }}roof-connections">Roof connections:</span></div></td>
                     <td style="width: 33%;"><div><span data-gem-help="{{ taxonomy_base }}roof-system-type">Roof system type:</span></div></td>
+                    <td style="width: 33%;"><div><span data-gem-help="{{ taxonomy_base }}roof-connections">Roof connections:</span></div></td>
                 </tr><tr>
-                    <td><select id="RoofCB5"></select></td>
                     <td><select id="RoofCB4"></select></td>
+                    <td><select id="RoofCB5"></select></td>
                </tr></table>
 
             </div>
@@ -228,8 +228,8 @@
                     <td><select id="FloorCB1"></select></td>
                     <td></td>
                </tr><tr>
-                    <td><div><span data-gem-help="{{ taxonomy_base }}floor-connections">Floor connections:</span></div></td>
                     <td><div><span data-gem-help="{{ taxonomy_base }}floor-system-type">Floor system type:</span></div></td>
+                    <td><div><span data-gem-help="{{ taxonomy_base }}floor-connections">Floor connections:</span></div></td>
                 </tr><tr>
                     <td><select id="FloorCB2"></select></td>
                     <td><select id="FloorCB3"></select></td>

--- a/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
+++ b/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
@@ -194,19 +194,11 @@ div.gem_help_highlight {
     position: absolute;
 }
 
-#RoofCB4 {
+#RoofCB4, #RoofCB5 {
     width: 85%;
 }
 
-#RoofCB5 {
-    width: 85%;
-}
-
-#FloorCB2 {
-    width: 85%;
-}
-
-#FloorCB3 {
+#FloorCB2, #FloorCB3 {
     width: 85%;
 }
 

--- a/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
+++ b/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
@@ -194,6 +194,22 @@ div.gem_help_highlight {
     position: absolute;
 }
 
+#RoofCB4 {
+    width: 85%;
+}
+
+#RoofCB5 {
+    width: 85%;
+}
+
+#FloorCB2 {
+    width: 85%;
+}
+
+#FloorCB3 {
+    width: 85%;
+}
+
 #resultE {
     width: 95%;
 }


### PR DESCRIPTION
Managed wrong caption in floor section and place form items in the proper level order from:
![old-layout](https://user-images.githubusercontent.com/1670278/51026397-b5bb4880-158e-11e9-85ad-43846683afe3.png)

to:
![new-layout](https://user-images.githubusercontent.com/1670278/51026416-c23fa100-158e-11e9-984a-649a4034d1f4.png)

Dropdown width is increased to show all the items descriptions.

Tests are green here: https://ci.openquake.org/job/zdevel_oq-platform-standalone/268/ 