### PR TITLE
Add 'explanation' button and service to taxtweb.

### DIFF
--- a/openquakeplatform_taxtweb/__init__.py
+++ b/openquakeplatform_taxtweb/__init__.py
@@ -17,4 +17,4 @@
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
 header_info = {"title": "TaxtWEB"}
-__version__ = '1.5.0'
+__version__ = '1.6.0'

--- a/openquakeplatform_taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform_taxtweb/static/taxtweb/js/taxtweb.js
@@ -2816,12 +2816,14 @@ function taxt_BuildTaxonomy()
 
         gem$('#resultE' + virt_sfx).val(ResTax);
         gem$('#permalink').attr("href", taxt_prefix + "/" +  ResTaxFull);
+        gem$('#do_explanation').attr("data_gem_taxonomy", ResTax);
     }
     else {
         gem_taxonomy_form = "";
         gem_taxonomy_form_full = "";
         gem$('#resultE' + virt_sfx).val(validate_msg);
         gem$('#permalink').attr("href", taxt_prefix);
+        gem$('#do_explanation').attr("data_gem_taxonomy", ResTax);
     }
 }
 
@@ -4728,4 +4730,32 @@ function populate(s, ret_s) {
         return (false);
     }
     return (true);
+}
+
+function show_explanation(obj)
+{
+    var tax = gem$(obj).attr('data_gem_taxonomy');
+
+    $.ajax({
+        url: '/taxtweb/explanation/' + tax,
+        type: 'GET',
+        cache: false,
+        processData: false,
+        contentType: false,
+        success: function(data) {
+            // CU+CIP/HBET:1,12
+            $('#explanation').html(data.message.replace(/;/g, '<br>'));
+            $('#explanation').dialog({
+                title: tax,
+                dialogClass: 'gem-jqueryui-dialog',
+                modal: true,
+                width: '600px',
+                buttons: {
+                    Ok: function() {
+                        $(this).dialog( "close" );
+                    }
+                }
+            });
+        }
+    });
 }

--- a/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_content.html
+++ b/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_content.html
@@ -256,7 +256,9 @@
             <p>Taxonomy string for this building typology: </p>
             <p><input id="resultE" type="text" size="80" maxlength="600"></input><input id="resultE_virt" type="hidden"></input></p>
             <p>Type of taxonomy:&nbsp;&nbsp;&nbsp;&nbsp;<select id="OutTypeCB"></select>
-            &nbsp;&nbsp;&nbsp;&nbsp;<a id="permalink" target="_blank" href="">Permalink</a></p>
+              &nbsp;&nbsp;&nbsp;&nbsp;<a id="permalink" target="_blank" href="">Permalink</a>
+                &nbsp;&nbsp;&nbsp;&nbsp;<a id="do_explanation" href="#" data_gem_taxonomy="" onclick="show_explanation(this); return false;">Explanation</a>
+            </p>
         </div>
     </div>
 </div>
@@ -271,3 +273,4 @@ Compose a taxonomy string by selecting items from the menus or typing directly i
     <button name="close_btn" style="position: absolute; bottom: 16px; right: 16px;">Close</button>
     </div>
 </div>
+<div id="explanation"></div>

--- a/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
+++ b/openquakeplatform_taxtweb/templates/taxtweb/incl_taxtweb_inlinecss.html
@@ -216,5 +216,13 @@ div.gem_help_highlight {
 #resultE {
     width: 95%;
 }
+
+.gem-jqueryui-dialog {
+    z-index: 1000;
+}
+
+.gem-jqueryui-dialog button.ui-dialog-titlebar-close {
+    display: none;
+}
 </style>
 <!-- incl_taxtweb_inlinecss.html END -->

--- a/openquakeplatform_taxtweb/test/click_and_help_test.py
+++ b/openquakeplatform_taxtweb/test/click_and_help_test.py
@@ -3,7 +3,7 @@ import unittest
 from openquake.moon import platform_get
 from selenium.webdriver.common.action_chains import ActionChains
 from openquake.moon import TimeoutError
-
+import time
 
 def hide_footer():
 
@@ -106,3 +106,22 @@ class VulnTaxonomiesTest(unittest.TestCase):
                                   timeout=5.0, is_regex=True)
         pla.window_close()
         pla.select_main_window()
+
+    def explanation_test(self):
+        pla = platform_get()
+        pla.get('/taxtweb/CU+CIP/HBET:1,12')
+
+        hide_footer()
+
+        exp_btn = pla.xpath_finduniq(
+            "//a[@id='do_explanation']")
+        exp_btn.click()
+
+        time.sleep(2)
+
+        res = pla.xpath_finduniq("//div[@id='explanation']")
+        self.assertEqual(res.text,
+                         ('Material type: Concrete, unreinforced\n'
+                          'Material technology: Cast-in-place concrete\n'
+                          'Number of storeys above ground - Range of'
+                          ' the number of storeys: between 1 and 12.'))

--- a/openquakeplatform_taxtweb/urls.py
+++ b/openquakeplatform_taxtweb/urls.py
@@ -25,6 +25,8 @@ from openquakeplatform_taxtweb import views
 
 app_name = 'taxtweb'
 urlpatterns = [
+    url(r'^explanation(?P<taxonomy>[^?]*)',
+        views.explanation, name='explanation'),
     url(r'^checker(?P<taxonomy>[^?]*)', views.checker, name='checker'),
     url(r'^(?P<taxonomy>[^?]*)', views.index, name='index'),
     url('', views.index, name='home'),

--- a/openquakeplatform_taxtweb/views.py
+++ b/openquakeplatform_taxtweb/views.py
@@ -16,7 +16,12 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with OpenQuake. If not, see <http://www.gnu.org/licenses/>.
 
+from django.http import HttpResponse
 from django.shortcuts import render
+import json
+from openquake.taxonomy.taxtweb_eng import Taxonomy
+from openquake.taxonomy.taxonomy2human import full_text2human
+
 try:
     from openquakeplatform.settings import STANDALONE
 except ImportError:
@@ -124,3 +129,25 @@ def checker(request, **kwargs):
                        taxt_prefix=taxt_prefix,
                        jquery="sim_dollar",
                        ))
+
+
+def explanation(request, **kwargs):
+    taxonomy = kwargs['taxonomy'][1:] if 'taxonomy' in kwargs else ""
+
+    print(taxonomy)
+    t = Taxonomy('Taxonomy', True)
+
+    full_text, full_res = t.process(taxonomy, 0)
+
+    if full_res is None:
+        err = 0
+        msg = full_text2human(full_text, no_unknown=True)
+    else:
+        err = 1
+        msg = full_res
+
+    res = {
+        'error': err,
+        'message': msg
+    }
+    return HttpResponse(json.dumps(res), content_type="application/json")


### PR DESCRIPTION
Expose 'explanation' functionality via REST api: **_hostname_**/taxtweb/explanation/**_taxonomy_**
 and use it with new 'explanation' button from taxtweb.
Tests are green here:
  * https://ci.openquake.org/job/zdevel_oq-platform-standalone/396/
  * https://ci.openquake.org/job/zdevel_oq-platform2/1120/