### PR TITLE
Send_keys and background-color

### DIFF
--- a/openquakeplatform_taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform_taxtweb/static/taxtweb/js/taxtweb.js
@@ -2832,7 +2832,7 @@ function taxt_BuildTaxonomy()
    output */
 function resultE_mgmt(event)
 {
-    var col_orange = '#ffdfbf', col_red = '#ffbfbf', col_green = '#bfffbf', col_transparent = '';
+    var col_orange = '#ffdfbfff', col_red = '#ffbfbfff', col_green = '#bfffbfff', col_transparent = '';
     var item = event.target;
     var taxonomy = $(item).val();
     var error = "";

--- a/openquakeplatform_taxtweb/static/taxtweb/js/taxtweb.js
+++ b/openquakeplatform_taxtweb/static/taxtweb/js/taxtweb.js
@@ -2832,7 +2832,7 @@ function taxt_BuildTaxonomy()
    output */
 function resultE_mgmt(event)
 {
-    var col_orange = '#ffdfbfff', col_red = '#ffbfbfff', col_green = '#bfffbfff', col_transparent = '';
+    var col_orange = '#ffdfbf', col_red = '#ffbfbf', col_green = '#bfffbf', col_transparent = '';
     var item = event.target;
     var taxonomy = $(item).val();
     var error = "";

--- a/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
+++ b/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
@@ -59,7 +59,8 @@ def make_function(func_name, taxonomy, run_slow):
         hide_footer()
 
         col_red = "rgba(255, 223, 191, 1)"
-        col_green = "rgba(191, 255, 191, 1)"
+        #col_green = "rgba(191, 255, 191, 1)"
+        col_green = "rgb(191, 255, 191)"
 
         taxonomy_loc = taxonomy
         if taxonomy_loc[-1] == '/':

--- a/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
+++ b/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
@@ -84,18 +84,22 @@ def make_function(func_name, taxonomy, run_slow):
 
         if run_slow:
             time.sleep(3)
-            resulte_tag.click()  # Positions the cursor at the end of string
+            resulte_tag.click()
+            resulte_tag.send_keys(Keys.End)  # Positions the cursor at the end of string
             if len(resulte_val) > 0 and resulte_val[-1] == '/':
                 resulte_tag.send_keys(Keys.BACK_SPACE)
                 resulte_tag, resulte_val = tag_and_val_get(
                     "//input[@id='resultE']", 20)
 
-            cur = resulte_val
-            while len(cur) > 0:
-                last = cur[-1]
+            while len(resulte_val) > 0:
+                prev_len = len(resulte_val)
+                last = resulte_val[-1]
                 resulte_tag.send_keys(Keys.BACK_SPACE)
                 resulte_tag, resulte_val = tag_and_val_get(
                     "//input[@id='resultE']", 20)
+
+                self.assertNotEqual(len(resulte_val), prev_len)
+
                 resulte_bgcol = resulte_tag.value_of_css_property(
                     'background-color')
                 self.assertNotEqual(resulte_bgcol, col_red)

--- a/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
+++ b/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
@@ -83,7 +83,7 @@ def make_function(func_name, taxonomy, run_slow):
             self.assertEqual(resulte_val, taxonomy_loc)
 
         if run_slow:
-            time.sleep(1)
+            time.sleep(3)
             resulte_tag.click()  # Positions the cursor at the end of string
             if len(resulte_val) > 0 and resulte_val[-1] == '/':
                 resulte_tag.send_keys(Keys.BACK_SPACE)

--- a/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
+++ b/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
@@ -85,7 +85,7 @@ def make_function(func_name, taxonomy, run_slow):
         if run_slow:
             time.sleep(3)
             resulte_tag.click()
-            resulte_tag.send_keys(Keys.End)  # Positions the cursor at the end of string
+            resulte_tag.send_keys(Keys.END)  # Positions the cursor at the end of string
             if len(resulte_val) > 0 and resulte_val[-1] == '/':
                 resulte_tag.send_keys(Keys.BACK_SPACE)
                 resulte_tag, resulte_val = tag_and_val_get(

--- a/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
+++ b/openquakeplatform_taxtweb/test/vuln_taxonomies_test.py
@@ -59,7 +59,6 @@ def make_function(func_name, taxonomy, run_slow):
         hide_footer()
 
         col_red = "rgba(255, 223, 191, 1)"
-        #col_green = "rgba(191, 255, 191, 1)"
         col_green = "rgb(191, 255, 191)"
 
         taxonomy_loc = taxonomy
@@ -84,7 +83,7 @@ def make_function(func_name, taxonomy, run_slow):
             self.assertEqual(resulte_val, taxonomy_loc)
 
         if run_slow:
-            time.sleep(3)
+            time.sleep(1)
             resulte_tag.click()
             resulte_tag.send_keys(Keys.END)  # Positions the cursor at the end of string
             if len(resulte_val) > 0 and resulte_val[-1] == '/':


### PR DESCRIPTION
Added attribute END for the send_keys when delete content of input taxonomy strings during the tests.
refactor while block code inside the vulnerability taxonomies test

The tests are green here: http://jenkins.gem.lan/job/zdevel_oq-platform-standalone/490/
The tests are green here: http://jenkins.gem.lan/job/zdevel_oq-platform2/1204/