### PR TITLE
fix 'https, https' case for HTTP_X_FORWARDED_PROTO http header

### DIFF
--- a/openquakeplatform_taxtweb/views.py
+++ b/openquakeplatform_taxtweb/views.py
@@ -46,7 +46,7 @@ def index(request, **kwargs):
             subtab_id = 1
 
     if 'HTTP_HOST' in request.META:
-        proto = (request.META['HTTP_X_FORWARDED_PROTO'] if
+        proto = (request.META['HTTP_X_FORWARDED_PROTO'].split(', ')[-1] if
                  'HTTP_X_FORWARDED_PROTO' in request.META else 'http')
         if request.META['HTTP_HOST'].startswith('taxtweb'):
             taxt_prefix = proto + '://' + request.META['HTTP_HOST']


### PR DESCRIPTION
HA Proxy technology manage HTTP_X_FORWARED_PROTO http header as a list instead a single string (with 'https' or 'http' as value)
Close #43