### PR TITLE
Permalink test

### DIFF
--- a/openquakeplatform_taxtweb/test/production_test.py
+++ b/openquakeplatform_taxtweb/test/production_test.py
@@ -25,7 +25,7 @@ class ProductionTest(unittest.TestCase):
     def permalink_test(self):
         pla = platform_get()
         prod_pla = pla.platform_create('admin', 'admin', jqheavy=None)
-        prod_pla.init(config=('https://platform.openquake.org', 'admin', 'admin', 'test@openquake.org', ''),
+        prod_pla.init(config=('https://tools.openquake.org', 'admin', 'admin', 'test@openquake.org', ''),
                       autologin=False)
         prod_pla.get('/taxtweb')
 


### PR DESCRIPTION
Changed url from platform to tools for permalink test.
The tests are green here: https://jenkins.vpn.openquake.org/job/zdevel_oq-platform-tools/15/